### PR TITLE
refactor: Add explicit return type to cn function

### DIFF
--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,6 +1,6 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
-export function cn(...inputs: ClassValue[]) {
+export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs))
 }


### PR DESCRIPTION
### 问题背景
The return type of the `cn` function is not explicitly specified. While TypeScript can infer it as `string` from `twMerge` and `clsx`, adding an explicit annotation enhances code clarity and documentation.

### 修改内容
- Modified `src/utils/cn.ts` to add an explicit `: string` return type annotation to the `cn` function.
- This change improves code readability and makes the function's contract clearer for developers and tools.
- No functional changes; the behavior remains the same.

### 验证方式
- The existing tests should continue to pass as this is a non-breaking change.
- Manual verification by checking the TypeScript compilation and ensuring no type errors are introduced.

### 其他信息
- No breaking changes.
- No documentation update required.
- No known limitations.