### PR TITLE
fix(mv3): resolve cold-start font application on default sites

### DIFF
--- a/src/inject/content-messaging.ts
+++ b/src/inject/content-messaging.ts
@@ -27,6 +27,9 @@ type DocumentLifecycleMessageOptions = {
   warn?: RuntimeWarningHandler
 }
 
+const DOCUMENT_LIFECYCLE_SEND_MAX_RETRIES = 4
+const DOCUMENT_LIFECYCLE_SEND_RETRY_MS = 250
+
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message
   if (
@@ -53,6 +56,12 @@ export function isExpectedRuntimeTeardownError(error: unknown): boolean {
     /Cannot read (?:properties|property) of undefined \(reading 'onMessage'\)/i.test(
       getErrorMessage(error)
     )
+  )
+}
+
+export function isTransientRuntimeSendError(error: unknown): boolean {
+  return /Could not establish connection|Receiving end does not exist|message port closed/i.test(
+    getErrorMessage(error)
   )
 }
 
@@ -83,25 +92,70 @@ export function sendDocumentLifecycleMessage(
     type
   }
 
-  try {
-    const runtime = chrome.runtime
-    if (!runtime || typeof runtime.sendMessage !== "function") {
-      return false
-    }
+  const attemptSend = (attempt = 0): void => {
+    if (options.isDisposed()) return
 
-    runtime.sendMessage(message, () => {
-      const error = chrome.runtime?.lastError
-      if (error && isExtensionContextInvalidated(error)) {
-        options.onExtensionContextInvalidated()
+    try {
+      const runtime = chrome.runtime
+      if (!runtime || typeof runtime.sendMessage !== "function") {
+        return
       }
-    })
+
+      runtime.sendMessage(message, () => {
+        const error = chrome.runtime?.lastError
+        if (!error) return
+
+        if (isExtensionContextInvalidated(error)) {
+          options.onExtensionContextInvalidated()
+          return
+        }
+
+        if (
+          attempt < DOCUMENT_LIFECYCLE_SEND_MAX_RETRIES &&
+          isTransientRuntimeSendError(error)
+        ) {
+          window.setTimeout(
+            () => attemptSend(attempt + 1),
+            DOCUMENT_LIFECYCLE_SEND_RETRY_MS
+          )
+          return
+        }
+
+        if (!isTransientRuntimeSendError(error)) {
+          options.warn?.(
+            "Failed to deliver FontAra document lifecycle message.",
+            error
+          )
+        }
+      })
+    } catch (error) {
+      if (isExtensionContextInvalidated(error)) {
+        options.onExtensionContextInvalidated()
+        return
+      }
+      if (!isTransientRuntimeSendError(error)) {
+        options.warn?.(
+          "Failed to send FontAra document lifecycle message.",
+          error
+        )
+      }
+    }
+  }
+
+  try {
+    attemptSend()
     return true
   } catch (error) {
     if (isExtensionContextInvalidated(error)) {
       options.onExtensionContextInvalidated()
       return false
     }
-    options.warn?.("Failed to send FontAra document lifecycle message.", error)
+    if (!isTransientRuntimeSendError(error)) {
+      options.warn?.(
+        "Failed to send FontAra document lifecycle message.",
+        error
+      )
+    }
     return false
   }
 }

--- a/src/inject/content-theme-scheduler.ts
+++ b/src/inject/content-theme-scheduler.ts
@@ -14,6 +14,8 @@ import {
 export type ContentApplyMode = "font-styles" | "full"
 
 const BACKGROUND_STORAGE_UPDATE_GRACE_MS = 25
+const BACKGROUND_RESPONSE_RETRY_MS = 2500
+const BACKGROUND_RESPONSE_RETRY_COUNT = 2
 
 export type ResolvedPageThemeRequestType =
   | typeof MESSAGE_TYPES_CS_TO_BG.DOCUMENT_RESUME
@@ -60,6 +62,7 @@ export function createContentThemeScheduler(
   let localApplyScheduledMode: ContentApplyMode | null = null
   let backgroundStorageUpdateTimeout: number | null = null
   let backgroundStorageUpdateMode: ContentApplyMode | null = null
+  let backgroundResponseRetryTimeout: number | null = null
   let backgroundCommandsEnabled = false
   let resolvedThemeRevision = 0
   let localFallbackActive = false
@@ -153,6 +156,13 @@ export function createContentThemeScheduler(
     })
   }
 
+  function clearBackgroundResponseRetries(): void {
+    if (backgroundResponseRetryTimeout !== null) {
+      clearTimeout(backgroundResponseRetryTimeout)
+      backgroundResponseRetryTimeout = null
+    }
+  }
+
   function clearBackgroundStorageUpdate(): void {
     if (backgroundStorageUpdateTimeout !== null) {
       clearTimeout(backgroundStorageUpdateTimeout)
@@ -188,28 +198,80 @@ export function createContentThemeScheduler(
     scheduleLocalThemeApply(mode)
   }
 
+  function scheduleBackgroundResponseRetries(
+    type: ResolvedPageThemeRequestType,
+    expectedRevision: number
+  ): void {
+    clearBackgroundResponseRetries()
+    let retryCount = 0
+
+    const retryBackgroundRequest = (): void => {
+      backgroundResponseRetryTimeout = null
+
+      if (options.isDisposed()) return
+      if (resolvedThemeRevision !== expectedRevision) return
+      if (retryCount >= BACKGROUND_RESPONSE_RETRY_COUNT) return
+
+      retryCount += 1
+      options.sendDocumentLifecycleMessage(type)
+      backgroundResponseRetryTimeout = window.setTimeout(
+        retryBackgroundRequest,
+        BACKGROUND_RESPONSE_RETRY_MS
+      )
+    }
+
+    backgroundResponseRetryTimeout = window.setTimeout(
+      retryBackgroundRequest,
+      BACKGROUND_RESPONSE_RETRY_MS
+    )
+  }
+
+  async function reconcileCleanUpThemeCommand(): Promise<void> {
+    if (options.isDisposed()) return
+
+    try {
+      const localTheme = await createFontaraPageThemeData(
+        window.location.href,
+        await readLocalThemeSettings(),
+        "full",
+        { googleFontCSSLoadMode: "cache-only" }
+      )
+
+      if (localTheme.font.active || localTheme.rtl.active) {
+        void applyResolvedPageTheme(localTheme, themeApplierCallbacks)
+        return
+      }
+    } catch (error) {
+      if (isExtensionContextInvalidated(error)) {
+        options.onExtensionContextInvalidated()
+        return
+      }
+      options.warn?.("Failed to reconcile FontAra cleanup command.", error)
+    }
+
+    cleanupResolvedPageTheme()
+  }
+
   function requestResolvedPageThemeOrFallback(
     type: ResolvedPageThemeRequestType,
     mode: ContentApplyMode = "full"
   ): void {
     const expectedRevision = resolvedThemeRevision
-    const sent = options.sendDocumentLifecycleMessage(type)
 
+    scheduleLocalThemeApply(mode)
+
+    const sent = options.sendDocumentLifecycleMessage(type)
     if (!sent) {
-      scheduleLocalThemeApply(mode)
       return
     }
 
-    window.setTimeout(() => {
-      if (!options.isDisposed() && resolvedThemeRevision === expectedRevision) {
-        scheduleLocalThemeApply(mode)
-      }
-    }, 100)
+    scheduleBackgroundResponseRetries(type, expectedRevision)
   }
 
   function applyThemeCommand(data: FontaraPageThemeCommandData): void {
     markBackgroundCommandsEnabled()
     clearBackgroundStorageUpdate()
+    clearBackgroundResponseRetries()
     resolvedThemeRevision += 1
     void applyResolvedPageTheme(data, themeApplierCallbacks)
   }
@@ -217,12 +279,14 @@ export function createContentThemeScheduler(
   function cleanUpThemeCommand(): void {
     markBackgroundCommandsEnabled()
     clearBackgroundStorageUpdate()
+    clearBackgroundResponseRetries()
     resolvedThemeRevision += 1
-    cleanupResolvedPageTheme()
+    void reconcileCleanUpThemeCommand()
   }
 
   function dispose(): void {
     clearBackgroundStorageUpdate()
+    clearBackgroundResponseRetries()
     localApplyQueuedMode = null
     localApplyScheduledMode = null
   }

--- a/src/inject/font-style-manager.ts
+++ b/src/inject/font-style-manager.ts
@@ -13,6 +13,37 @@ const CUSTOM_FONT_STYLES_ID = "fontara-custom-font-styles"
 const DYNAMIC_FONT_ID = "fontara-dynamic-font"
 const GOOGLE_FONT_STYLES_ID = "fontara-google-font-styles"
 
+let customCssStyleObserver: MutationObserver | null = null
+let observedCustomCssBody: HTMLElement | null = null
+
+function getCustomCssStyleHost(): HTMLElement {
+  return document.body ?? getStyleHost()
+}
+
+function stopWatchingCustomCssStyleOrder(): void {
+  customCssStyleObserver?.disconnect()
+  customCssStyleObserver = null
+  observedCustomCssBody = null
+}
+
+function ensureCustomCssStyleLast(styleElement: HTMLStyleElement): void {
+  const host = getCustomCssStyleHost()
+  if (host.lastElementChild !== styleElement) {
+    host.appendChild(styleElement)
+  }
+
+  if (observedCustomCssBody === host && customCssStyleObserver) return
+
+  stopWatchingCustomCssStyleOrder()
+  observedCustomCssBody = host
+  customCssStyleObserver = new MutationObserver(() => {
+    if (host.lastElementChild !== styleElement) {
+      host.appendChild(styleElement)
+    }
+  })
+  customCssStyleObserver.observe(host, { childList: true })
+}
+
 export function removeInlineFontStyles(): void {
   for (const root of getDocumentAndShadowStyleRoots()) {
     root.querySelectorAll("[style*='fontara-font']").forEach((element) => {
@@ -52,16 +83,19 @@ export function injectResolvedFontStyles(
   if (data.customCSS) {
     removeEditableFontStyles()
     removeInlineFontStyles()
-    upsertStyle(CUSTOM_CSS_ID, data.customCSS)
+    const styleElement = upsertStyle(CUSTOM_CSS_ID, data.customCSS)
+    ensureCustomCssStyleLast(styleElement)
     return true
   }
 
+  stopWatchingCustomCssStyleOrder()
   removeStyle(CUSTOM_CSS_ID)
   refreshEditableFontStyles()
   return false
 }
 
 export function removeFontStyles(): void {
+  stopWatchingCustomCssStyleOrder()
   removeStyle(FONT_STYLES_ID)
   removeStyle(DYNAMIC_FONT_ID)
   removeEditableFontStyles()

--- a/tests/inject/performance.test.ts
+++ b/tests/inject/performance.test.ts
@@ -141,6 +141,9 @@ test("storage changes schedule the active injection pipeline", () => {
     /requestResolvedPageThemeOrFallback\(\s*MESSAGE_TYPES_CS_TO_BG\.DOCUMENT_UPDATE,\s*scheduledMode\s*\)/
   )
   assert.match(schedulerSource, /BACKGROUND_STORAGE_UPDATE_GRACE_MS/)
+  assert.match(schedulerSource, /BACKGROUND_RESPONSE_RETRY_MS/)
+  assert.match(schedulerSource, /scheduleLocalThemeApply\(mode\)/)
+  assert.match(schedulerSource, /reconcileCleanUpThemeCommand/)
   assert.match(
     schedulerSource,
     /type ContentApplyMode = "font-styles" \| "full"/
@@ -253,6 +256,8 @@ test("content messaging helpers own runtime messaging and teardown errors", () =
     messagingSource,
     /export function isExpectedRuntimeTeardownError/
   )
+  assert.match(messagingSource, /isTransientRuntimeSendError/)
+  assert.match(messagingSource, /DOCUMENT_LIFECYCLE_SEND_MAX_RETRIES/)
   assert.match(messagingSource, /runtime\.sendMessage\(message/)
   assert.match(messagingSource, /chrome\.runtime\?\.lastError/)
   assert.match(messagingSource, /onExtensionContextInvalidated/)

--- a/tests/unit/content-messaging.test.ts
+++ b/tests/unit/content-messaging.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict"
+import test, { afterEach } from "node:test"
+
+import { MESSAGE_TYPES_CS_TO_BG } from "../../src/utils/message"
+
+const originalGlobals = {
+  chrome: Reflect.get(globalThis, "chrome") as unknown,
+  window: Reflect.get(globalThis, "window") as unknown
+}
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalGlobals)) {
+    Reflect.set(globalThis, key, value)
+  }
+})
+
+test("sendDocumentLifecycleMessage retries transient MV3 service worker errors", async () => {
+  let sendAttempts = 0
+  let lastError: { message: string } | undefined
+
+  Reflect.set(globalThis, "window", {
+    location: { href: "https://github.com/" },
+    setTimeout
+  })
+
+  Reflect.set(globalThis, "chrome", {
+    runtime: {
+      get lastError() {
+        return lastError
+      },
+      sendMessage(_message: unknown, callback: () => void) {
+        sendAttempts += 1
+        if (sendAttempts < 3) {
+          lastError = {
+            message:
+              "Could not establish connection. Receiving end does not exist."
+          }
+        } else {
+          lastError = undefined
+        }
+        callback()
+      }
+    }
+  })
+
+  const { sendDocumentLifecycleMessage } = await import(
+    "../../src/inject/content-messaging"
+  )
+
+  const delivered = sendDocumentLifecycleMessage(
+    MESSAGE_TYPES_CS_TO_BG.DOCUMENT_UPDATE,
+    {
+      isDisposed: () => false,
+      onExtensionContextInvalidated: () => {
+        assert.fail("transient send errors must not dispose the runtime")
+      },
+      scriptId: "test-script"
+    }
+  )
+
+  assert.equal(delivered, true)
+  assert.equal(sendAttempts, 1)
+
+  await new Promise((resolve) => setTimeout(resolve, 600))
+
+  assert.equal(sendAttempts, 3)
+})
+
+test("sendDocumentLifecycleMessage stays silent after transient MV3 send failures", async () => {
+  let sendAttempts = 0
+  let warnCalls = 0
+
+  Reflect.set(globalThis, "window", {
+    location: { href: "https://github.com/" },
+    setTimeout
+  })
+
+  Reflect.set(globalThis, "chrome", {
+    runtime: {
+      get lastError() {
+        return {
+          message:
+            "Could not establish connection. Receiving end does not exist."
+        }
+      },
+      sendMessage(_message: unknown, callback: () => void) {
+        sendAttempts += 1
+        callback()
+      }
+    }
+  })
+
+  const { sendDocumentLifecycleMessage } = await import(
+    "../../src/inject/content-messaging"
+  )
+
+  sendDocumentLifecycleMessage(MESSAGE_TYPES_CS_TO_BG.DOCUMENT_UPDATE, {
+    isDisposed: () => false,
+    onExtensionContextInvalidated: () => {
+      assert.fail("transient send errors must not dispose the runtime")
+    },
+    scriptId: "test-script",
+    warn: () => {
+      warnCalls += 1
+    }
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 1500))
+
+  assert.equal(sendAttempts, 5)
+  assert.equal(warnCalls, 0)
+})

--- a/tests/unit/content-theme-scheduler.test.ts
+++ b/tests/unit/content-theme-scheduler.test.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict"
+import { createRequire } from "node:module"
+import test, { afterEach } from "node:test"
+
+import { DEFAULT_VALUES, STORAGE_KEYS } from "../../src/config/storage"
+import type { WebsiteItem } from "../../src/definitions"
+import { MESSAGE_TYPES_CS_TO_BG } from "../../src/utils/message"
+
+type CssModuleLoader = (module: { exports: string }) => void
+type RequireWithCssExtensions = {
+  extensions: Record<string, CssModuleLoader | undefined>
+}
+
+const require = createRequire(import.meta.url)
+const requireWithCssExtensions = require as unknown as RequireWithCssExtensions
+const originalCSSExtension = requireWithCssExtensions.extensions[".css"]
+const originalGlobals = {
+  chrome: Reflect.get(globalThis, "chrome") as unknown,
+  document: Reflect.get(globalThis, "document") as unknown,
+  window: Reflect.get(globalThis, "window") as unknown
+}
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalGlobals)) {
+    Reflect.set(globalThis, key, value)
+  }
+
+  requireWithCssExtensions.extensions[".css"] = originalCSSExtension
+})
+
+function installCSSModuleMock(): void {
+  requireWithCssExtensions.extensions[".css"] = (module) => {
+    module.exports = `
+      @font-face {
+        font-family: "Vazirmatn-Fontara";
+        src: url("assets/fonts/vazirmatn/Vazirmatn.woff2") format("woff2");
+      }
+    `
+  }
+}
+
+function installRuntimeMocks(
+  options: { href?: string; websiteList?: WebsiteItem[] } = {}
+): {
+  lifecycleMessages: string[]
+  styleIds: Set<string>
+} {
+  const lifecycleMessages: string[] = []
+  const styleIds = new Set<string>()
+  const matchingWebsite: WebsiteItem = {
+    isActive: true,
+    regex: "^https://github\\.com/.*$",
+    url: "https://github.com"
+  }
+  const values = {
+    [STORAGE_KEYS.CUSTOM_FONT_LIST]: [],
+    [STORAGE_KEYS.DISABLED_FOR]: [],
+    [STORAGE_KEYS.ENABLED_BY_DEFAULT]: false,
+    [STORAGE_KEYS.ENABLED_FOR]: ["github.com"],
+    [STORAGE_KEYS.EXTENSION_ENABLED]: true,
+    [STORAGE_KEYS.GOOGLE_FONTS_ENABLED]: false,
+    [STORAGE_KEYS.SELECTED_FONT]: DEFAULT_VALUES.SELECTED_FONT,
+    [STORAGE_KEYS.SITE_PROFILES]: [],
+    [STORAGE_KEYS.SYSTEM_FONTS_ENABLED]: false,
+    [STORAGE_KEYS.TEXT_STROKE]: 0,
+    [STORAGE_KEYS.WEBSITE_LIST]: options.websiteList ?? [matchingWebsite]
+  }
+
+  const elementsById = new Map<string, { id: string; textContent: string }>()
+  const bodyElement = {
+    childNodes: [],
+    id: "body",
+    isConnected: true,
+    localName: "body",
+    tagName: "BODY"
+  }
+
+  Reflect.set(globalThis, "document", {
+    body: bodyElement,
+    createElement(tagName: string) {
+      const element = {
+        id: "",
+        textContent: "",
+        remove() {}
+      }
+      if (tagName.toLowerCase() === "style") {
+        Object.defineProperty(element, "id", {
+          set(nextId: string) {
+            styleIds.add(nextId)
+          }
+        })
+      }
+      return element
+    },
+    documentElement: {},
+    getElementById(id: string) {
+      return elementsById.get(id) ?? null
+    },
+    head: {
+      appendChild(element: { id: string; textContent: string }) {
+        if (element.id) {
+          elementsById.set(element.id, element)
+        }
+      }
+    },
+    querySelectorAll() {
+      return []
+    }
+  })
+
+  Reflect.set(globalThis, "window", {
+    location: {
+      href: options.href ?? "https://github.com/mimalef70/fontara"
+    },
+    requestIdleCallback(
+      callback: (deadline: { timeRemaining: () => number }) => void
+    ) {
+      callback({ timeRemaining: () => 50 })
+      return 1
+    },
+    setTimeout
+  })
+
+  Reflect.set(globalThis, "chrome", {
+    runtime: {
+      getURL(path: string) {
+        return `chrome-extension://fontara/${path}`
+      },
+      get lastError() {
+        return undefined
+      },
+      sendMessage(message: { type: string }) {
+        lifecycleMessages.push(message.type)
+      }
+    },
+    storage: {
+      local: {
+        get(
+          keys: string | Record<string, unknown>,
+          callback: (items: Record<string, unknown>) => void
+        ) {
+          if (typeof keys === "string") {
+            callback({ [keys]: values[keys as keyof typeof values] })
+            return
+          }
+
+          callback({ ...keys, ...values })
+        },
+        set(_items: Record<string, unknown>, callback: () => void) {
+          callback()
+        }
+      }
+    }
+  })
+
+  return { lifecycleMessages, styleIds }
+}
+
+test("requestResolvedPageThemeOrFallback applies local theme before waiting for background", async () => {
+  installCSSModuleMock()
+  const runtime = installRuntimeMocks()
+
+  const { createContentThemeScheduler } = await import(
+    "../../src/inject/content-theme-scheduler"
+  )
+
+  const scheduler = createContentThemeScheduler({
+    isDisposed: () => false,
+    onExtensionContextInvalidated: () => {},
+    sendDocumentLifecycleMessage: (type) => {
+      runtime.lifecycleMessages.push(type)
+      return true
+    }
+  })
+
+  scheduler.requestResolvedPageThemeOrFallback(
+    MESSAGE_TYPES_CS_TO_BG.DOCUMENT_UPDATE
+  )
+
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  scheduler.dispose()
+
+  assert.ok(runtime.styleIds.has("fontara-font-styles"))
+  assert.deepEqual(runtime.lifecycleMessages, [
+    MESSAGE_TYPES_CS_TO_BG.DOCUMENT_UPDATE
+  ])
+})
+
+test("cleanUpThemeCommand keeps active default-site styles when local storage says active", async () => {
+  installCSSModuleMock()
+  const runtime = installRuntimeMocks()
+
+  const { createContentThemeScheduler } = await import(
+    "../../src/inject/content-theme-scheduler"
+  )
+
+  const scheduler = createContentThemeScheduler({
+    isDisposed: () => false,
+    onExtensionContextInvalidated: () => {},
+    sendDocumentLifecycleMessage: () => true
+  })
+
+  scheduler.requestResolvedPageThemeOrFallback(
+    MESSAGE_TYPES_CS_TO_BG.DOCUMENT_UPDATE
+  )
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  assert.ok(runtime.styleIds.has("fontara-font-styles"))
+
+  scheduler.cleanUpThemeCommand()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  scheduler.dispose()
+
+  assert.ok(runtime.styleIds.has("fontara-font-styles"))
+})
+
+test("cleanUpThemeCommand removes styles when local storage says inactive", async () => {
+  installCSSModuleMock()
+  const runtime = installRuntimeMocks({
+    href: "https://example.com/",
+    websiteList: [
+      {
+        isActive: true,
+        regex: "^https://github\\.com/.*$",
+        url: "https://github.com"
+      }
+    ]
+  })
+
+  const { createContentThemeScheduler } = await import(
+    "../../src/inject/content-theme-scheduler"
+  )
+
+  const scheduler = createContentThemeScheduler({
+    isDisposed: () => false,
+    onExtensionContextInvalidated: () => {},
+    sendDocumentLifecycleMessage: () => true
+  })
+
+  scheduler.cleanUpThemeCommand()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  scheduler.dispose()
+
+  assert.equal(runtime.styleIds.size, 0)
+})


### PR DESCRIPTION
- Apply local theme immediately on page load
- Retry document lifecycle messages on transient service worker errors
- Reconcile stale background CLEAN_UP state with local storage

Fixes #158

## Summary

Fix MV3 cold-start issue where font/theme was not applied immediately on first page load.

Ensures correct initialization during early page render, improves reliability of service worker communication on startup, and syncs CLEAN_UP state with local storage.

## Type

- [x ] Bug fix
- [ ] Site fix
- [ ] Feature
- [x ] Runtime architecture
- [ ] UI
- [ ] Build, CI, or release
- [ ] Documentation

## Testing

- [ ] Not run
- [x ] `pnpm check`
- [ ] `pnpm build:all`
- [ ] `pnpm lint:extension`
- [ ] `pnpm test:browser:chrome`
- [ ] `FONTARA_FIREFOX_BROWSER_TESTS=1 FONTARA_FIREFOX_HEADLESS=1 pnpm test:browser:firefox`

## Site Fix Checklist

- [ x] Not a site fix
- [ ] CSS file is mapped in `src/config/site-fixes.ts`
- [ ] Site entry exists in `src/config/sites.ts`
- [ ] Selectors avoid icons, code, hidden UI, and volatile hashes
- [ ] Fallback variables do not contain `var(--fontara-font)`
- [ ] Matching/profile/RTL behavior is covered by tests where relevant

## Risk

-
